### PR TITLE
Add music playback in game levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,12 @@
 <body>
 <canvas id="game" width="800" height="400"></canvas>
 <div id="ui"></div>
+<audio id="bgmusic" src="music.mp3" loop style="display:none"></audio>
 <script>
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const ui = document.getElementById('ui');
+const music = document.getElementById('bgmusic');
 
 const GRAVITY = 0.6;
 let speed = 4; // base speed, increases with level
@@ -49,6 +51,7 @@ function resetLevel(resetLives) {
   spawnTimer = 0;
   obstacles = [];
   resetPlayer();
+  music.play().catch(() => {});
 }
 
 function nextLevel() {
@@ -58,11 +61,13 @@ function nextLevel() {
     resetLevel(false);
   } else {
     gameState = 'victory';
+    music.pause();
   }
 }
 
 function gameOver() {
   gameState = 'gameover';
+  music.pause();
 }
 
 const METER = 100; // basic unit for obstacle spacing


### PR DESCRIPTION
## Summary
- embed an audio tag for `music.mp3`
- control background music via script
- pause music on game over or victory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68744c11cadc8333bc014fa8781dfc6c