### PR TITLE
Add parallax effect for background

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <style>
   body { margin: 0; background: #111; color: #fff; font-family: Arial, sans-serif; overflow: hidden; }
   canvas {
-    background: #222 url('fond.png') no-repeat center center;
+    background: #222 url('fond.png') repeat-x bottom center;
     background-size: cover;
     display: block;
     width: 100vw;
@@ -67,6 +67,7 @@ resizeCanvas();
 
 const GRAVITY = 0.6;
 let speed = 4; // base speed, increases with level
+const BG_SCROLL_FACTOR = 0.3; // parallax speed factor for background
 const JUMP_VELOCITY = -24; // starting jump velocity
 // Adjust hitboxes and obstacle size so jumps are survivable
 const PLAYER_HITBOX_X = 30;
@@ -104,6 +105,7 @@ function resetLevel(resetLives) {
   timeRemaining = 60;
   spawnTimer = 0;
   cameraX = 0;
+  canvas.style.backgroundPosition = '0px 0px';
   obstacles = [];
   resetPlayer();
   startMusic();
@@ -171,6 +173,7 @@ function update(delta) {
   }
 
   cameraX += speed;
+  canvas.style.backgroundPosition = `${-cameraX * BG_SCROLL_FACTOR}px 0px`;
 
   obstacles = obstacles.filter(ob => ob.x - cameraX + ob.width > 0);
 


### PR DESCRIPTION
## Summary
- animate the background to scroll slower than the floor
- reset the background position whenever a level starts
- enable background image to repeat horizontally so it scrolls smoothly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68746d43a9188333b389f4a2096c849f