### PR TITLE
Switch to random obstacle images

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,11 @@ let floorPattern = null;
 floorImg.onload = () => {
   floorPattern = ctx.createPattern(floorImg, 'repeat');
 };
-const blockImg = new Image();
-blockImg.src = 'block.jpeg';
+const obstacleImages = ['block.jpeg', 'block1.jpeg', 'block2.jpeg'].map(src => {
+  const img = new Image();
+  img.src = src;
+  return img;
+});
 const FLOOR_HEIGHT = 80;
 
 function startMusic() {
@@ -74,8 +77,8 @@ const JUMP_VELOCITY = -24; // starting jump velocity
 // Adjust hitboxes and obstacle size so jumps are survivable
 const PLAYER_HITBOX_X = 30;
 const PLAYER_HITBOX_Y = 20;
-const OBSTACLE_WIDTH = 100;
-const OBSTACLE_HEIGHT = 140;
+const OBSTACLE_WIDTH = 120;
+const OBSTACLE_HEIGHT = 160;
 const OBSTACLE_HITBOX = 10;
 
 const player = {
@@ -140,16 +143,13 @@ function spawnObstacle() {
   spawnTimer = (gap / speed) * (1000 / 60);
   const obstacleWidth = OBSTACLE_WIDTH;
   const obstacleHeight = OBSTACLE_HEIGHT;
-  const hue = Math.floor(Math.random() * 360);
-  const saturation = 50 + Math.floor(Math.random() * 50);
-  const lightness = 40 + Math.floor(Math.random() * 40);
-  const color = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+  const img = obstacleImages[Math.floor(Math.random() * obstacleImages.length)];
   obstacles.push({
     x: cameraX + canvas.width,
     y: canvas.height - FLOOR_HEIGHT - obstacleHeight,
     width: obstacleWidth,
     height: obstacleHeight,
-    color
+    img
   });
 }
 
@@ -222,11 +222,7 @@ function drawFloor() {
 
 function drawObstacles() {
   obstacles.forEach(ob => {
-    ctx.drawImage(blockImg, ob.x - cameraX, ob.y, ob.width, ob.height);
-    ctx.fillStyle = ob.color;
-    ctx.globalCompositeOperation = 'source-atop';
-    ctx.fillRect(ob.x - cameraX, ob.y, ob.width, ob.height);
-    ctx.globalCompositeOperation = 'source-over';
+    ctx.drawImage(ob.img, ob.x - cameraX, ob.y, ob.width, ob.height);
   });
 }
 


### PR DESCRIPTION
## Summary
- use three obstacle images instead of single colored block
- standardize obstacle size

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68747508b8808333a1c9cb1fe33c6e5e